### PR TITLE
Improve sed IPv4 regex for loading plain lists

### DIFF
--- a/sub2rbl
+++ b/sub2rbl
@@ -176,11 +176,11 @@ uciLoad rbl | while read rbl ; do
       sed -n 's/^.*|.*| *\([0-9\.][0-9\.]*\) .*$/\1/p' "$tmpFile" > "$tmpFile2"
     else
       logLine 3 "Loading plain IP list"
-      sed -n 's/^ *\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)[ 	]*.*$/\1/p' "$tmpFile" > "$tmpFile2"
+      sed -n 's/^ *\([1-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)[ 	]*.*$/\1/p' "$tmpFile" > "$tmpFile2"
     fi
   elif [ $setType = net ] ; then
       logLine 3 "Loading plain Net list"
-      sed -n 's#^ *\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[/0-9]*\)[ 	]*.*$#\1#p' "$tmpFile" > "$tmpFile2"
+      sed -n 's#^ *\([1-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[/0-9]*\)[ 	]*.*$#\1#p' "$tmpFile" > "$tmpFile2"
   fi
   if [ -n "$whiteList" ] ; then
     logLine 3 "Applying whitelist"


### PR DESCRIPTION
0.0.0.0/8 is reserved [according to IANA since 1981](https://www.iana.org/assignments/ipv4-address-space/ipv4-address-space.xhtml#note2). 0.x.x.x IPv4 addresses shouldn't be routable and not end up in an RBL. 

Though https://sigs.interserver.net/iprbl.txt contains 0.0.0.0 resulting in "ipset v6.29: Error in line 1: Null-valued element, cannot be stored in a hash type of set". 

This fix excludes 0.x.x.x addresses to end up in ipset lists.